### PR TITLE
docs: correct shell newline character.

### DIFF
--- a/cleaning-workflow/README.md
+++ b/cleaning-workflow/README.md
@@ -16,49 +16,49 @@ python clean_times.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "..
 ```
 3. produce `DateTime` column in each dataset
 ```curl
-python clean_datetime.py "../../data/source-data/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv" /
-python clean_datetime.py "../../data/source-data/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv" /
-python clean_datetime.py "../../data/source-data/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv" /
-python clean_datetime.py "../../data/source-data/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv" / 
-python clean_datetime.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" / 
-python clean_datetime.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" /
-python clean_datetime.py "../../data/source-data/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" /
+python clean_datetime.py "../../data/source-data/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv";
+python clean_datetime.py "../../data/source-data/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv";
+python clean_datetime.py "../../data/source-data/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv";
+python clean_datetime.py "../../data/source-data/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv";
+python clean_datetime.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv";
+python clean_datetime.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv";
+python clean_datetime.py "../../data/source-data/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv";
 python clean_datetime.py "../../data/source-data/ped-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv"
 ```
 4. clean the addresses
 ```curl
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/clean-data/moco-crash-2003-2015-clean.csv" /
-python clean_addresses.py "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" /
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/clean-data/moco-crash-2003-2015-clean.csv";
+python clean_addresses.py "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv";
 python clean_addresses.py "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv"
 ```
 
 5. update geocoding with more accurate lat/lon data
 This step takes a really long time to run. It might take longer than an hour if you clean every file. If you are working on analysis that doesn't require accurate lat/lon data, you can skip this step. 
 ```curl
-python geocode.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv" /
-python geocode.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv" /
-python geocode.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv" /
-python geocode.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv" /
-python geocode.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" /
+python geocode.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv";
+python geocode.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv";
+python geocode.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv";
+python geocode.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv";
+python geocode.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv";
 python geocode.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" 
 ```
 
 6. merge the bike/ped information into the master files for 2013-2022
 ```curl
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2022-clean.csv" /
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2022-clean.csv";
 
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2021-clean.csv" /
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2021-clean.csv";
 
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2020-clean.csv" /
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2020-clean.csv";
 
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2019-clean.csv" /
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2019-clean.csv";
 
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2013-2018-clean.csv" /
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2013-2018-clean.csv";
 ```
 
 7. combine into master file 
@@ -69,11 +69,11 @@ python make_master_file.py "../../data/clean-data/moco-crash-2022-clean.csv" "..
 
 8. jitter the points
 ```curl
-python jitter.py "../../data/clean-data/moco-crash-2022-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2022-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2021-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2021-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2020-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2020-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2019-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2019-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2013-2018-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2013-2018-jittered.csv" /
+python jitter.py "../../data/clean-data/moco-crash-2022-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2022-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2021-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2021-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2020-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2020-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2019-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2019-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2013-2018-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2013-2018-jittered.csv";
 python jitter.py "../../data/clean-data/moco-crash-2003-2015-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2003-2015-jittered.csv"
 ```
 
@@ -86,34 +86,34 @@ python make_geojson.py "../../data/clean-data/jittered/master-crashes-jittered.c
 Just copy the below code and paste it into terminal:
 Note: This long commend doesn't include the geocoding step because that takes too long.
 ```curl
-python main_data_cleaning.py "../../data/source-data/moco-crash-2013-2018.csv" "../../data/source-data/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" /
-python clean_times.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv"  /
-python clean_datetime.py "../../data/source-data/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv" /
-python clean_datetime.py "../../data/source-data/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv" /
-python clean_datetime.py "../../data/source-data/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv" /
-python clean_datetime.py "../../data/source-data/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv" / 
-python clean_datetime.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" / 
-python clean_datetime.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" /
-python clean_datetime.py "../../data/source-data/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" /
-python clean_datetime.py "../../data/source-data/ped-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" /
-python clean_addresses.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/clean-data/moco-crash-2003-2015-clean.csv" /
-python clean_addresses.py "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" /
-python clean_addresses.py "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" /
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2022-clean.csv" /
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2021-clean.csv" /
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2020-clean.csv" /
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2019-clean.csv" /
-python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2013-2018-clean.csv" /
+python main_data_cleaning.py "../../data/source-data/moco-crash-2013-2018.csv" "../../data/source-data/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv";
+python clean_times.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv" ;
+python clean_datetime.py "../../data/source-data/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv";
+python clean_datetime.py "../../data/source-data/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv";
+python clean_datetime.py "../../data/source-data/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv";
+python clean_datetime.py "../../data/source-data/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv";
+python clean_datetime.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv";
+python clean_datetime.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/cleaning-process/moco-crash-2003-2015.csv";
+python clean_datetime.py "../../data/source-data/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv";
+python clean_datetime.py "../../data/source-data/ped-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/moco-crash-2022.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/moco-crash-2021.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/moco-crash-2020.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/moco-crash-2019.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/moco-crash-2013-2018.csv";
+python clean_addresses.py "../../data/cleaning-process/moco-crash-2003-2015.csv" "../../data/clean-data/moco-crash-2003-2015-clean.csv";
+python clean_addresses.py "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv";
+python clean_addresses.py "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv";
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2022.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2022-clean.csv";
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2021.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2021-clean.csv";
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2020.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2020-clean.csv";
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2019.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2019-clean.csv";
+python merge_bike_ped.py "../../data/cleaning-process/moco-crash-2013-2018.csv" "../../data/cleaning-process/bike-crashes-2013-2023.csv" "../../data/cleaning-process/ped-crashes-2013-2023.csv" "../../data/clean-data/moco-crash-2013-2018-clean.csv";
 python make_master_file.py "../../data/clean-data/moco-crash-2022-clean.csv" "../../data/clean-data/moco-crash-2021-clean.csv" "../../data/clean-data/moco-crash-2020-clean.csv" "../../data/clean-data/moco-crash-2019-clean.csv" "../../data/clean-data/moco-crash-2013-2018-clean.csv" "../../data/clean-data/moco-crash-2003-2015-clean.csv" "../../data/clean-data/master-crashes.csv"
-python jitter.py "../../data/clean-data/moco-crash-2022-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2022-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2021-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2021-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2020-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2020-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2019-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2019-jittered.csv" /
-python jitter.py "../../data/clean-data/moco-crash-2013-2018-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2013-2018-jittered.csv" /
+python jitter.py "../../data/clean-data/moco-crash-2022-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2022-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2021-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2021-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2020-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2020-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2019-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2019-jittered.csv";
+python jitter.py "../../data/clean-data/moco-crash-2013-2018-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2013-2018-jittered.csv";
 python jitter.py "../../data/clean-data/moco-crash-2003-2015-clean.csv" "../../data/clean-data/geocoded/master_crash_geocoded.csv" "../../data/clean-data/jittered/moco-crash-2003-2015-jittered.csv"
 ```


### PR DESCRIPTION
Using "/" was intended to join multiple shell lines, but a semicolon is
the correct character for that.

To confirm, try this:

```bash
❯ echo "first line" / echo "second line"
```

The result is this, because " / " tried like a file path passed to `echo`:

```text
first line / echo second line
```
